### PR TITLE
Modular settings custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v 1.1.0
+
+* Added custom partial to Modular Settings menu to allow more control
+* Removed system dependencies to allow use on any system
+
 # v 1.0.0
 
 * Initial release.

--- a/module.json
+++ b/module.json
@@ -17,26 +17,7 @@
     "manifest": "https://github.com/vtt-lair/simbuls-athenaeum/releases/latest/download/module.json",
     "download": "https://github.com/vtt-lair/simbuls-athenaeum/releases/download/v1.0.0/module.zip",
     "changelog": "https://github.com/vtt-lair/simbuls-athenaeum/blob/main/CHANGELOG.md",
-    "relationships": {
-        "systems": [
-            {
-                "id": "dnd5e",
-                "type": "system",
-                "manifest": "https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/raw/2.0.2/system.json",
-                "compatibility": {
-                    "verified": "2.0.2"
-                }
-            },
-            {
-              "id": "sw5e",
-              "type": "system",
-              "manifest": "https://github.com/unrealkakeman89/sw5e/releases/download/2.0.3.2.3.7/system.json",
-              "compatibility": {
-                "verified": "2.0.3.2.3.7"
-              }
-            }
-        ]
-    },
+    "relationships": {},
     "compatibility": {
         "minimum": "10",
         "verified": "10"

--- a/templates/ModularSettings.html
+++ b/templates/ModularSettings.html
@@ -1,8 +1,8 @@
 {{#*inline "settingPartial"}}
+{{#if this.isCustom}}
+{{> (lookup this "customPartial") this}}
+{{else}}
 <div class="form-group">
-    {{#if this.isCustom}}
-    {{> (lookup this "customPartial") this}}
-    {{else}}
     <label>{{this.name}}</label>
     <div class="form-fields">
 
@@ -33,8 +33,8 @@
     </div>
 
     <p class="notes">{{this.hint}}</p>
-    {{/if}}
 </div>
+{{/if}}
 {{/inline}}
 
 {{#*inline "menuPartial" }}

--- a/templates/ModularSettings.html
+++ b/templates/ModularSettings.html
@@ -1,5 +1,8 @@
 {{#*inline "settingPartial"}}
 <div class="form-group">
+    {{#if this.isCustom}}
+    {{> (lookup this "customPartial") this}}
+    {{else}}
     <label>{{this.name}}</label>
     <div class="form-fields">
 
@@ -30,6 +33,7 @@
     </div>
 
     <p class="notes">{{this.hint}}</p>
+    {{/if}}
 </div>
 {{/inline}}
 
@@ -47,9 +51,9 @@
 
     <!-- Navigation Tabs -->
     <nav class="sheet-tabs tabs" data-group="sections">
-        {{#each data.tabs as |data tab|}} 
+        {{#each data.tabs as |data tab|}}
           <a class="item" data-tab="{{tab}}"><i class="{{data.faIcon}}"></i> {{localize data.tabLabel}} </a>
-        {{/each}} 
+        {{/each}}
     </nav>
 
     <!-- Main Content Section -->
@@ -59,7 +63,7 @@
             <div class="tab-hint">{{ localize data.hint }}</div>
             <div class="settings-list">
               {{#each data.settings}}
-                {{> settingPartial}} 
+                {{> settingPartial}}
               {{/each}}
               {{#each data.menus}}
                 {{> menuPartial}}


### PR DESCRIPTION
A quick PR to enable settings to define a custom partial to use for configuring.

This is required for features used in custom cover levels in Simbuls Cover Calculator